### PR TITLE
fix: platform admin support + fix 500 error on accounts endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -21,3 +21,7 @@ SMTP_PASS=your_app_password
 # Default Admin Account
 DEFAULT_ADMIN_EMAIL=admin@example.com
 DEFAULT_ADMIN_API_KEY=demo_api_key_change_me
+
+# Platform Admin (Super Admin) - comma-separated emails
+# These users can see and switch to ALL accounts in the system
+PLATFORM_ADMIN_EMAILS=wenendy@touchworks.com.br

--- a/.env.production
+++ b/.env.production
@@ -32,5 +32,9 @@ SMTP_PASS=your_app_password
 DEFAULT_ADMIN_EMAIL=admin@yourcompany.com
 DEFAULT_ADMIN_API_KEY=your_secure_api_key_change_immediately
 
+# Platform Admin (Super Admin) - comma-separated emails
+# These users can see and switch to ALL accounts in the system
+PLATFORM_ADMIN_EMAILS=wenendy@touchworks.com.br
+
 # CORS Configuration
 FRONTEND_URL=https://your-frontend-app.vercel.app

--- a/src/controllers/accountController.js
+++ b/src/controllers/accountController.js
@@ -1,13 +1,39 @@
 const { Account, User, UserAccount } = require('../models');
 const { v4: uuidv4 } = require('uuid');
 const crypto = require('crypto');
+const { isPlatformAdmin } = require('../utils/platformAdmin');
 
 // Listar todas as contas do usuário logado
 const getUserAccounts = async (req, res) => {
   try {
     const userId = req.user?.id;
+    const userEmail = req.user?.email;
     if (!userId) {
       return res.status(401).json({ error: 'Usuário não autenticado' });
+    }
+
+    // Platform admin (super admin) pode ver TODAS as contas
+    if (isPlatformAdmin(userEmail)) {
+      console.log(`🔑 Platform admin detectado: ${userEmail} - retornando todas as contas`);
+      const allAccounts = await Account.findAll({
+        where: { is_active: true },
+        attributes: ['id', 'name', 'display_name', 'description', 'avatar_url', 'plan', 'is_active'],
+        order: [['created_at', 'ASC']]
+      });
+
+      const accounts = allAccounts.map(acc => ({
+        id: acc.id,
+        name: acc.name,
+        display_name: acc.display_name || acc.name,
+        description: acc.description,
+        avatar_url: acc.avatar_url,
+        plan: acc.plan,
+        role: 'owner', // Platform admin tem role owner em todas as contas
+        permissions: {},
+        is_active: acc.is_active
+      }));
+
+      return res.json({ accounts });
     }
 
     const userAccounts = await UserAccount.findAll({
@@ -54,6 +80,39 @@ const switchAccount = async (req, res) => {
 
     if (!accountId) {
       return res.status(400).json({ error: 'ID da conta é obrigatório' });
+    }
+
+    const userEmail = req.user?.email;
+
+    // Platform admin pode acessar qualquer conta
+    if (isPlatformAdmin(userEmail)) {
+      console.log(`🔑 Platform admin ${userEmail} trocando para conta: ${accountId}`);
+      const account = await Account.findOne({
+        where: { id: accountId, is_active: true }
+      });
+
+      if (!account) {
+        return res.status(404).json({ error: 'Conta não encontrada ou inativa' });
+      }
+
+      await User.update(
+        { current_account_id: accountId },
+        { where: { id: userId } }
+      );
+
+      return res.json({
+        success: true,
+        account: {
+          id: account.id,
+          name: account.name,
+          display_name: account.display_name || account.name,
+          description: account.description,
+          avatar_url: account.avatar_url,
+          plan: account.plan,
+          role: 'owner',
+          permissions: {}
+        }
+      });
     }
 
     // Verificar se o usuário tem acesso à conta

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,5 +1,6 @@
 const { verifyToken: verifyJWT } = require('../utils/jwtUtils');
 const { Account, User, UserAccount } = require('../models');
+const { isPlatformAdmin } = require('../utils/platformAdmin');
 
 const authenticateToken = async (req, res, next) => {
   try {
@@ -58,6 +59,36 @@ const authenticateToken = async (req, res, next) => {
     let userRole = 'member';
     let userPermissions = {};
 
+    // Platform admin (super admin) tem acesso total a qualquer conta
+    if (isPlatformAdmin(user.email)) {
+      console.log(`🔑 Platform admin detectado no auth middleware: ${user.email}`);
+      userRole = 'owner';
+      userPermissions = {};
+
+      if (!currentAccount || !user.current_account_id) {
+        // Buscar primeira conta ativa do sistema para o platform admin
+        const firstAccount = await Account.findOne({
+          where: { is_active: true },
+          order: [['created_at', 'ASC']]
+        });
+
+        if (firstAccount) {
+          console.log(`✅ Platform admin: definindo conta ${firstAccount.name} como atual`);
+          await user.update({ current_account_id: firstAccount.id });
+          currentAccount = firstAccount;
+        } else {
+          return res.status(500).json({ error: 'Nenhuma conta ativa no sistema' });
+        }
+      }
+
+      req.user = user;
+      req.account = currentAccount;
+      req.userRole = userRole;
+      req.userPermissions = userPermissions;
+      req.isPlatformAdmin = true;
+      return next();
+    }
+
     // Se não há conta atual definida, buscar a primeira conta ativa do usuário
     if (!currentAccount || !user.current_account_id) {
       console.log(`🔍 Usuário ${user.email} sem conta atual definida, buscando primeira conta ativa...`);
@@ -104,6 +135,7 @@ const authenticateToken = async (req, res, next) => {
     req.account = currentAccount;
     req.userRole = userRole;
     req.userPermissions = userPermissions;
+    req.isPlatformAdmin = false;
     next();
   } catch (error) {
     if (error.message.includes('Token expired')) {

--- a/src/utils/platformAdmin.js
+++ b/src/utils/platformAdmin.js
@@ -1,0 +1,18 @@
+/**
+ * Utilitário para verificar se um usuário é administrador da plataforma (super admin).
+ * 
+ * Configuração via variável de ambiente:
+ * PLATFORM_ADMIN_EMAILS=email1@example.com,email2@example.com
+ * 
+ * O platform admin tem acesso a TODAS as contas do sistema.
+ */
+
+const isPlatformAdmin = (userEmail) => {
+  if (!userEmail) return false;
+  
+  const adminEmails = (process.env.PLATFORM_ADMIN_EMAILS || '').split(',').map(e => e.trim().toLowerCase()).filter(Boolean);
+  
+  return adminEmails.includes(userEmail.toLowerCase());
+};
+
+module.exports = { isPlatformAdmin };


### PR DESCRIPTION
- Add platformAdmin utility to check PLATFORM_ADMIN_EMAILS env var
- getUserAccounts: platform admin sees ALL accounts in the system
- switchAccount: platform admin can switch to any account
- Auth middleware: platform admin bypasses UserAccount check
- Add PLATFORM_ADMIN_EMAILS to .env and .env.production